### PR TITLE
Skip TotalSupplyUpdated when they occur with a mint or redeem

### DIFF
--- a/eagleproject/core/sigs.py
+++ b/eagleproject/core/sigs.py
@@ -12,7 +12,20 @@ CHAINLINK_TOK_ETH_PRICE = encode_hex(keccak(b"tokEthPrice(string)"))
 # tokUsdPrice(string calldata symbol)
 CHAINLINK_TOK_USD_PRICE = encode_hex(keccak(b"tokUsdPrice(string)"))
 
+########
 # Events
+########
 TRANSFER = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+# OGN Staking
 SIG_EVENT_STAKED = encode_hex(keccak(b"Staked(address,uint256)"))
 SIG_EVENT_WITHDRAWN = encode_hex(keccak(b"Withdrawn(address,uint256)"))
+
+# OUSD
+SIG_EVENT_TOTAL_SUPPLY_UPDATED = encode_hex(
+    keccak(b"TotalSupplyUpdated(uint256,uint256,uint256)")
+)
+
+# Vault
+SIG_EVENT_MINT = encode_hex(keccak(b"Mint(address,uint256)"))
+SIG_EVENT_REDEEM = encode_hex(keccak(b"Redeem(address,uint256)"))

--- a/eagleproject/notify/triggers/ousd_mint.py
+++ b/eagleproject/notify/triggers/ousd_mint.py
@@ -1,13 +1,10 @@
 from decimal import Decimal
-from eth_hash.auto import keccak
 from eth_abi import decode_single
-from eth_utils import encode_hex, decode_hex
+from eth_utils import decode_hex
 from django.db.models import Q
 from core.common import format_ousd_human
+from core.sigs import SIG_EVENT_MINT, SIG_EVENT_REDEEM
 from notify.events import event_normal
-
-SIG_EVENT_MINT = encode_hex(keccak(b"Mint(address,uint256)"))
-SIG_EVENT_REDEEM = encode_hex(keccak(b"Redeem(address,uint256)"))
 
 
 def get_mint_redeem_events(logs):

--- a/eagleproject/notify/triggers/ousd_totalsupply.py
+++ b/eagleproject/notify/triggers/ousd_totalsupply.py
@@ -1,14 +1,14 @@
 from decimal import Decimal
-from eth_hash.auto import keccak
 from eth_abi import decode_single
-from eth_utils import encode_hex, decode_hex
+from eth_utils import decode_hex
 from django.db.models import Q
 from core.common import format_ousd_human
-from notify.events import event_low
-
-SIG_EVENT_TOTAL_SUPPLY_UPDATED = encode_hex(
-    keccak(b"TotalSupplyUpdated(uint256,uint256,uint256)")
+from core.sigs import (
+    SIG_EVENT_MINT,
+    SIG_EVENT_REDEEM,
+    SIG_EVENT_TOTAL_SUPPLY_UPDATED,
 )
+from notify.events import event_high
 
 
 def get_supply_events(logs):
@@ -18,11 +18,22 @@ def get_supply_events(logs):
     ).order_by('block_number')
 
 
+def has_mint_or_burn(logs, tx_hash):
+    """ Check if the transaction also has a mint or burn event """
+    return logs.filter(transaction_hash=tx_hash).filter(
+        Q(topic_0=SIG_EVENT_MINT)
+        | Q(topic_0=SIG_EVENT_REDEEM)
+    ).count() > 0
+
+
 def run_trigger(new_logs):
     """ Look for mints and redeems """
     events = []
 
     for ev in get_supply_events(new_logs):
+        if has_mint_or_burn(new_logs, ev.transaction_hash):
+            continue
+
         (
             total_supply,
             rebasing_credits,
@@ -33,7 +44,7 @@ def run_trigger(new_logs):
         )
 
         events.append(
-            event_low(
+            event_high(
                 "Total supply updated   👛",
                 "Total supply is now {} OUSD".format(
                     format_ousd_human(Decimal(total_supply) / Decimal(1e18)),


### PR DESCRIPTION
As the title says.  Showing notifications for TotalSupplyUpdated during mint/redeems are confusing.  This skips them if the transaction is paired with one of those events.  It also raises the severity to make it more prominent if it does occur without either of those events.

CC @tomlinton @franckc 
Ref: #24