### PR TITLE
Switch to one day trailing APR

### DIFF
--- a/eagleproject/core/templates/apr_index.html
+++ b/eagleproject/core/templates/apr_index.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<h1>APY {{seven_day_apy|floatformat:2}}% <small>seven day average</small></h1>
+<h1>APY {{seven_day_apy|floatformat:2}}% <small>one day average</small></h1>
 
 <p>Daily APR for the last thirty days:</p>
 

--- a/eagleproject/core/templates/dashboard.html
+++ b/eagleproject/core/templates/dashboard.html
@@ -228,7 +228,7 @@
 <div class="top-three columns">
     <div class="module">
         <div class="label">
-            Trailing&nbsp;<a href="/apr">7-Day</a>&nbsp;APY
+            Trailing&nbsp;<a href="/apr">1-Day</a>&nbsp;APY
         </div>
         {{apy|floatformat:2}}%
     </div>


### PR DESCRIPTION
Calculates the APR by using the OUSD rebase ratio.

This has the upside that it's simple to calculate and exactly matches user's balance changes.

It has the downside that the number it pulls from only gets updated on rebases, making this method less acurate. It's bit iffy using it on only one day, but that's the data we have at the moment.