### PR TITLE
Breaks supply alert thresholds into 3 of increasing severity

### DIFF
--- a/eagleproject/notify/triggers/ctoken_totalborrows.py
+++ b/eagleproject/notify/triggers/ctoken_totalborrows.py
@@ -2,9 +2,11 @@ from decimal import Decimal
 from statistics import mean
 from core.blockchain.addresses import CONTRACT_ADDR_TO_NAME
 from core.common import dict_append
-from notify.events import event_critical, event_high
+from notify.events import event_critical, event_high, event_normal
 
-PERCENT_DIFF_THRESHOLD = Decimal(0.05)
+PERCENT_DIFF_THRESHOLD_NOTICE = Decimal(0.05)
+PERCENT_DIFF_THRESHOLD_WARNING = Decimal(0.10)
+PERCENT_DIFF_THRESHOLD_CRITICAL = Decimal(0.15)
 
 
 def get_past_comparison(ctoken_snaps):
@@ -26,6 +28,7 @@ def run_trigger(recent_ctoken_snapshots):
     """ Trigger on extreme supply changes in cTokens """
     events = []
     snaps = {}
+    ev_func = event_normal
 
     for snap in recent_ctoken_snapshots:
         dict_append(snaps, snap.address, snap)
@@ -33,38 +36,77 @@ def run_trigger(recent_ctoken_snapshots):
     for ctoken_address in snaps:
         total_borrows_comp = get_past_comparison(snaps[ctoken_address])
         total_borrows_current = snaps[ctoken_address][0].total_borrows
-        diff_threshold = total_borrows_comp * PERCENT_DIFF_THRESHOLD
+        notice_diff_threshold = (
+            total_borrows_comp * PERCENT_DIFF_THRESHOLD_NOTICE
+        )
+        warning_diff_threshold = (
+            total_borrows_comp * PERCENT_DIFF_THRESHOLD_WARNING
+        )
+        critical_diff_threshold = (
+            total_borrows_comp * PERCENT_DIFF_THRESHOLD_CRITICAL
+        )
+
+        title = ""
+        msg = ""
+        threshold = 0
 
         if total_borrows_current < total_borrows_comp:
             diff = total_borrows_comp - total_borrows_current
 
-            if diff > diff_threshold:
-                events.append(event_critical(
-                    "Compound cToken Total Borrows Fluctuation   🚨",
+            if diff > critical_diff_threshold:
+                ev_func = event_critical
+                threshold = critical_diff_threshold
+
+            elif diff > warning_diff_threshold:
+                ev_func = event_high
+                threshold = warning_diff_threshold
+
+            elif diff > notice_diff_threshold:
+                ev_func = event_normal
+                threshold = notice_diff_threshold
+
+            if threshold:
+                title = "Compound cToken Total Borrows Fluctuation   🚨"
+                msg = (
                     "The cToken {} borrows have dropped more than {}% between "
                     "snapshots.".format(
                         CONTRACT_ADDR_TO_NAME.get(
                             ctoken_address,
                             ctoken_address
                         ),
-                        round(PERCENT_DIFF_THRESHOLD * Decimal(100))
+                        round(threshold * Decimal(100))
                     )
-                ))
+                )
 
         else:
             diff = total_borrows_current - total_borrows_comp
 
-            if diff > diff_threshold:
-                events.append(event_high(
-                    "Compound cToken Total Borrows Fluctuation   🚨",
+            if diff > critical_diff_threshold:
+                ev_func = event_critical
+                threshold = critical_diff_threshold
+
+            elif diff > warning_diff_threshold:
+                ev_func = event_high
+                threshold = warning_diff_threshold
+
+            elif diff > notice_diff_threshold:
+                ev_func = event_normal
+                threshold = notice_diff_threshold
+
+            if threshold:
+                title = "Compound cToken Total Borrows Fluctuation   🚨"
+                msg = (
                     "The cToken {} has gained more than {}% borrows between "
                     "snapshots.".format(
                         CONTRACT_ADDR_TO_NAME.get(
                             ctoken_address,
                             ctoken_address
                         ),
-                        round(PERCENT_DIFF_THRESHOLD * Decimal(100))
+                        round(threshold * Decimal(100))
                     )
-                ))
+                )
+
+        if threshold:
+            events.append(ev_func(title, msg))
 
     return events


### PR DESCRIPTION
Breaks the supply/borrows/liquidity notification thresholds into three separate ones.

For compound, it's 5/10/15.  For Aave, it's 2/5/10.  Can adjust them as needed later.

Closes #51 