### PR TITLE
Event tags and OGN partitioning

### DIFF
--- a/eagleproject/core/blockchain/rpc.py
+++ b/eagleproject/core/blockchain/rpc.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import math
 import requests
 from decimal import Decimal

--- a/eagleproject/core/common.py
+++ b/eagleproject/core/common.py
@@ -129,3 +129,13 @@ def decode_ipfs_hash(hex_hash):
     return multihash.to_b58_string(
         multihash.from_hex_string(hex_hash)
     )
+
+
+def first(it, match):
+    """ Find first element of iter to match match """
+    if not callable(match):
+        match = lambda x: x == match
+    for i in it:
+        if match(i):
+            return i
+    return None

--- a/eagleproject/core/views.py
+++ b/eagleproject/core/views.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from django.shortcuts import render, redirect
 from django.http import HttpResponse, JsonResponse
 from django.db import connection
-from django.db.models import F, Q, Sum, ExpressionWrapper, DateTimeField, DurationField
+from django.db.models import F, Q, Sum
 from core.blockchain.addresses import (
     OUSD,
     USDT,

--- a/eagleproject/eagleproject/settings.py
+++ b/eagleproject/eagleproject/settings.py
@@ -189,6 +189,10 @@ EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS") == "true"
 ADMINS = [("Engineering", "engineering@originprotocol.com")]
 DISCORD_BOT_NAME = os.environ.get("DISCORD_BOT_NAME", "OUSD Analytics Bot")
 DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL")
+OGN_DISCORD_WEBHOOK_URL = os.environ.get(
+    "OGN_DISCORD_WEBHOOK_URL",
+    DISCORD_WEBHOOK_URL
+)
 # Comma delimited User IDs (e.g. 'Mike Shultz#5937' is '386238710255058954')
 # You can get this by Right clicking the name and "Copy ID" with developer mode
 DISCORD_WEBHOOK_AT = os.environ.get("DISCORD_WEBHOOK_AT")

--- a/eagleproject/notify/actions/__init__.py
+++ b/eagleproject/notify/actions/__init__.py
@@ -30,6 +30,7 @@ def create_actions_from_events(events):
             details=ev.details,
             severity=ev.severity,
             color=SEVERITY_COLOR[ev.severity],
+            tags=ev.tags,
         ))
 
         if ev.severity > highest_severity:

--- a/eagleproject/notify/events/__init__.py
+++ b/eagleproject/notify/events/__init__.py
@@ -8,11 +8,12 @@ from notify.models import EventSeen
 class Event:
     """ An event worthy of an action """
     def __init__(self, title, details, severity=Severity.NORMAL,
-                 stamp=datetime.utcnow()):
+                 stamp=datetime.utcnow(), tags=['default']):
         self._severity = severity or Severity.NORMAL
         self._title = title
         self._details = details
         self._stamp = stamp
+        self._tags = tags
 
     def __str__(self):
         return "{} [{}] {}: {}".format(
@@ -57,25 +58,47 @@ class Event:
     def stamp(self):
         return self._stamp
 
+    @property
+    def tags(self):
+        return self._tags
 
-def event_critical(title, details, stamp=datetime.utcnow()):
+
+def event_critical(title, details, stamp=datetime.utcnow(), tags=None):
     """ Create a critical severity event """
-    return Event(title, details, stamp=stamp, severity=Severity.CRITICAL)
+    return Event(
+        title,
+        details,
+        stamp=stamp,
+        severity=Severity.CRITICAL,
+        tags=tags
+    )
 
 
-def event_high(title, details, stamp=datetime.utcnow()):
+def event_high(title, details, stamp=datetime.utcnow(), tags=None):
     """ Create a high severity event """
-    return Event(title, details, stamp=stamp, severity=Severity.HIGH)
+    return Event(
+        title,
+        details,
+        stamp=stamp,
+        severity=Severity.HIGH,
+        tags=tags
+    )
 
 
-def event_normal(title, details, stamp=datetime.utcnow()):
+def event_normal(title, details, stamp=datetime.utcnow(), tags=None):
     """ Create a normal severity event """
-    return Event(title, details, stamp=stamp, severity=Severity.NORMAL)
+    return Event(
+        title,
+        details,
+        stamp=stamp,
+        severity=Severity.NORMAL,
+        tags=tags
+    )
 
 
-def event_low(title, details, stamp=datetime.utcnow()):
+def event_low(title, details, stamp=datetime.utcnow(), tags=None):
     """ Create a low severity event """
-    return Event(title, details, stamp=stamp, severity=Severity.LOW)
+    return Event(title, details, stamp=stamp, severity=Severity.LOW, tags=tags)
 
 
 def seen_filter(events, since):
@@ -101,3 +124,8 @@ def seen_filter(events, since):
             })
 
     return filtered
+
+
+def tag_filter(events, tag):
+    """ Filter out any event not tagged with `tag` """
+    return filter(lambda e: tag in e.tags, events)

--- a/eagleproject/notify/triggers/staking_buffer.py
+++ b/eagleproject/notify/triggers/staking_buffer.py
@@ -5,6 +5,7 @@ from notify.events import event_critical, event_high, event_normal, event_low
 LOW_YELLOW = 2000000
 LOW_ORANGE = 1000000
 LOW_RED = 500000
+EVENT_TAGS = ['ogn']
 
 
 def run_trigger(ogn_staking_snapshot):
@@ -26,7 +27,8 @@ def run_trigger(ogn_staking_snapshot):
             event_critical(
                 "Impossible staking condition   ⁉️",
                 "OGN Staking has less OGN than expected rewards "
-                "({} OGN)".format(diff)
+                "({} OGN)".format(diff),
+                tags=EVENT_TAGS
             )
         )
     elif diff < LOW_RED:
@@ -36,7 +38,8 @@ def run_trigger(ogn_staking_snapshot):
                 "Critical OGN Staking contract buffer   🟥",
                 "OGN Staking contract rewards buffer down to {}".format(
                     format_ogn_human(diff)
-                )
+                ),
+                tags=EVENT_TAGS
             )
         )
     elif diff < LOW_ORANGE:
@@ -45,7 +48,8 @@ def run_trigger(ogn_staking_snapshot):
                 "Low OGN Staking contract buffer   🟧",
                 "OGN Staking contract rewards buffer down to {}".format(
                     format_ogn_human(diff)
-                )
+                ),
+                tags=EVENT_TAGS
             )
         )
     elif diff < LOW_YELLOW:
@@ -54,7 +58,8 @@ def run_trigger(ogn_staking_snapshot):
                 "OGN Staking contract buffer   🟨",
                 "OGN Staking contract rewards buffer down to {}".format(
                     format_ogn_human(diff)
-                )
+                ),
+                tags=EVENT_TAGS
             )
         )
     # Debug only
@@ -64,7 +69,8 @@ def run_trigger(ogn_staking_snapshot):
                 "Nominal OGN Staking contract buffer   🟩",
                 "OGN Staking contract rewards buffer down to {}".format(
                     format_ogn_human(diff)
-                )
+                ),
+                tags=EVENT_TAGS
             )
         )
 

--- a/eagleproject/notify/triggers/staking_paused.py
+++ b/eagleproject/notify/triggers/staking_paused.py
@@ -4,6 +4,8 @@ from core.blockchain.sigs import SIG_EVENT_STAKING_PAUSED
 from core.blockchain.const import TRUE_256BIT
 from notify.events import event_high
 
+EVENT_TAGS = ['ogn']
+
 
 def get_pause_events(logs):
     """ Get DepositsPaused/DepositsUnpaused events """
@@ -26,7 +28,8 @@ def run_trigger(new_logs):
                 "OGN Staking was {} by {}".format(
                     "paused" if is_pause else "unpaused",
                     address,
-                )
+                ),
+                tags=EVENT_TAGS
             )
         )
 

--- a/eagleproject/notify/triggers/staking_rates.py
+++ b/eagleproject/notify/triggers/staking_rates.py
@@ -3,15 +3,13 @@ from decimal import Decimal
 from eth_hash.auto import keccak
 from eth_utils import encode_hex, decode_hex
 from eth_abi import decode_single
-from django.db.models import Q
 from notify.events import event_high
 
+EVENT_TAGS = ['ogn']
 SIG_EVENT_NEW_DURATIONS = encode_hex(
     keccak(b"NewDurations(address,uint256[])")
 )
 SIG_EVENT_NEW_RATES = encode_hex(keccak(b"NewRates(address,uint256[])"))
-FALSE_256BIT = "0x0000000000000000000000000000000000000000000000000000000000000000"
-TRUE_256BIT = "0x0000000000000000000000000000000000000000000000000000000000000001"
 DAYS_365_SECONDS = 31536000
 
 
@@ -57,7 +55,11 @@ def run_trigger(new_logs):
             )
 
         events.append(
-            event_high("OGN Staking Rates Changed   🧮", durations_string)
+            event_high(
+                "OGN Staking Rates Changed   🧮",
+                durations_string,
+                tags=EVENT_TAGS
+            )
         )
 
     return events

--- a/eagleproject/notify/triggers/staking_stake.py
+++ b/eagleproject/notify/triggers/staking_stake.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import timedelta
 from decimal import Decimal
 from eth_abi import decode_single
@@ -18,6 +17,8 @@ from notify.events import event_normal
 from notify.triggers.staking_rates import DAYS_365_SECONDS
 
 log = get_logger(__name__)
+
+EVENT_TAGS = ['ogn']
 
 
 def get_stake_withdrawn_events(logs):
@@ -53,7 +54,8 @@ def run_trigger(new_logs):
                     "{} OGN was {}".format(
                         format_ousd_human(Decimal(amount) / Decimal(1e18)),
                         "staked" if is_staked else "withdrawn",
-                    )
+                    ),
+                    tags=EVENT_TAGS
                 )
             )
         elif ev.topic_0 == SIG_EVENT_STAKED:
@@ -67,7 +69,7 @@ def run_trigger(new_logs):
 
             # There should be a stake in the DB
             if len(stakes) < 1:
-                log.warning('No stakes found in DB', file=sys.stderr)
+                log.warning('No stakes found in DB')
 
             # Non-standard stake types
             elif stakes[0].stake_type == 1:
@@ -77,7 +79,7 @@ def run_trigger(new_logs):
             else:
                 log.warning('Unsupported stake_type {}'.format(
                     stakes[0].stake_type
-                ), file=sys.stderr)
+                ))
 
             duration_dt = timedelta(seconds=duration)
 
@@ -92,7 +94,8 @@ def run_trigger(new_logs):
                         verb,
                         duration_dt.days,
                         apy
-                    )
+                    ),
+                    tags=EVENT_TAGS
                 )
             )
         elif ev.topic_0 == SIG_EVENT_WITHDRAWN:
@@ -106,7 +109,8 @@ def run_trigger(new_logs):
                     "Withdrawn 🍰",
                     "{} OGN was withdrawn".format(
                         format_ousd_human(Decimal(amount) / Decimal(1e18))
-                    )
+                    ),
+                    tags=EVENT_TAGS
                 )
             )
 


### PR DESCRIPTION
Adds "tags" to events(an array of strings) that can be used by actions.  Tags are set when the event is created in the triggers.  Right now, this amounts to "ogn" being the only useful tag that the `DiscordWebhook` action will detect and try and use a webhook override, if it's availalbe.  Should be pretty easy to add others if we decide to go that route.

Already configured envkey to set the override for `#ogn-monitoring`.

This also takes care of a minor bug so I may just merge and deploy this in a little bit.

Closes #36