### PR TITLE
Staking math correction

### DIFF
--- a/eagleproject/core/blockchain/harvest/transactions.py
+++ b/eagleproject/core/blockchain/harvest/transactions.py
@@ -362,7 +362,8 @@ def maybe_store_stake_withdrawn_record(log, block):
         "user_address": staker,
         "is_staked": is_staked_event,
         "amount": amount,
-        "staked_amount": int(slot(log["data"], 1), 16) / 1e18 if is_withdrawn_event else 0,
+        # This is apparently withdrawn amount and the name makes no sense
+        "staked_amount": int(slot(log["data"], 1), 16) / E_18 if is_withdrawn_event else 0,
         "duration": duration,
         "staked_duration": timedelta(days=duration),
         "rate": rate,


### PR DESCRIPTION
Fixes staking duration math (used in `/api/v1/staking_stats_by_duration`) to include numbers in mature stakes that have not yet been withdrawn.  Basically changes staking math to only sum stakes and withdraws per user and ignore maturity dates.  Numbers check out this time between the two API endpoints.

Wasn't able to do it in a single query so it got a little out of hand...

Closes #81