### PR TITLE
Discord webhook description limits

### DIFF
--- a/eagleproject/core/common.py
+++ b/eagleproject/core/common.py
@@ -151,3 +151,10 @@ def first(it, match):
         if match(i):
             return i
     return None
+
+
+def truncate_elipsis(v, max_length=2048, elipsis=" ..."):
+    """ Truncate a string to max_length and append elipsis to the end """
+    if len(v) <= max_length:
+        return v
+    return v[:max_length - len(elipsis)] + elipsis

--- a/eagleproject/notify/actions/objects.py
+++ b/eagleproject/notify/actions/objects.py
@@ -3,7 +3,7 @@ import requests
 from time import sleep
 from django.conf import settings
 from django.core.mail import send_mail
-from core.common import Severity, first
+from core.common import Severity, first, truncate_elipsis
 from core.logging import get_logger
 
 log = get_logger(__name__)
@@ -84,7 +84,7 @@ class DiscordWebhook(Action):
                 "embeds": [
                     {
                         "title": self.summary,
-                        "description": self.details,
+                        "description": truncate_elipsis(self.details),
                         "color": self.color,
                     }
                 ]


### PR DESCRIPTION
Discord webhooks embeds only allow 2048 characters in their `descrpition` field.  This adds truncation to the compound prop trigger, and general truncation to the action if it comes to that.

Closes #92