### PR TITLE
Adjust notification language and thresholds

### DIFF
--- a/eagleproject/notify/triggers/aave_lpc_total_liquidity.py
+++ b/eagleproject/notify/triggers/aave_lpc_total_liquidity.py
@@ -69,8 +69,7 @@ def run_trigger(recent_aave_reserve_snapshots):
                 title = "Aave Liquidity Fluctuation   🚨"
                 msg = (
                     "The LendingPoolCore {} reserve has dropped more than {}% "
-                    "between snapshots. This could indicate issues or a rush "
-                    "on capital.".format(
+                    "between snapshots.".format(
                         CONTRACT_ADDR_TO_NAME.get(asset, asset),
                         round(threshold * Decimal(100))
                     )


### PR DESCRIPTION
Removes some editorialization I put into some notifications that makes no sense in hindsight.  And bumps the cUSDT notification thresholds for totalSupply and totalBorrows because it's such a smaller pool on the whole.