### PR TITLE
Switch back to 30 days for APY calculations

### DIFF
--- a/eagleproject/core/blockchain/apy.py
+++ b/eagleproject/core/blockchain/apy.py
@@ -24,7 +24,7 @@ def get_trailing_apr(block=None):
     on rebases, making this method less accurate. It's bit iffy using it
     on only one day, but that's the data we have at the moment.
     """
-    days = 29.00
+    days = 30.00
 
     # Check cache first
     global PREV_APR


### PR DESCRIPTION
We temp changed to 29 days to avoid a data bug due to the resolution upgrade. This undoes that that, since we no longer need it.