### PR TITLE
Change staking notification thresholds to 250k, 100k, and 50k

### DIFF
--- a/eagleproject/notify/triggers/staking_buffer.py
+++ b/eagleproject/notify/triggers/staking_buffer.py
@@ -2,9 +2,9 @@ from django.conf import settings
 from core.common import format_ogn_human
 from notify.events import event_critical, event_high, event_normal, event_low
 
-LOW_YELLOW = 2000000
-LOW_ORANGE = 1000000
-LOW_RED = 500000
+LOW_YELLOW = 250000
+LOW_ORANGE = 100000
+LOW_RED = 50000
 EVENT_TAGS = ['ogn']
 
 


### PR DESCRIPTION
Adjusts staking notification thresholds since we're letting it drain further.