### PR TITLE
add OUSD relative supply chart

### DIFF
--- a/eagleproject/core/templates/dashboard.html
+++ b/eagleproject/core/templates/dashboard.html
@@ -440,7 +440,7 @@
     </div>
 
     <div class="iframe-holder">
-        <iframe src="https://dune.com/embeds/1149021/1961517/6e89e0d2-0c00-4616-a7b1-9151c25dbcc9" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
+        <iframe src="https://dune.com/embeds/1149021/1961517/633d97df-efad-455e-b032-23fa027013a4" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
         </iframe>
     </div>
 

--- a/eagleproject/core/templates/dashboard.html
+++ b/eagleproject/core/templates/dashboard.html
@@ -440,7 +440,7 @@
     </div>
 
     <div class="iframe-holder">
-        <iframe src="https://dune.com/embeds/1149021/1961517/e6381414-de7c-4e0d-b91a-d8ec2bfbead3" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
+        <iframe src="https://dune.com/embeds/1149021/1961517/6ea00091-4df9-478b-aa9c-8f907856fc92" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
         </iframe>
     </div>
 

--- a/eagleproject/core/templates/dashboard.html
+++ b/eagleproject/core/templates/dashboard.html
@@ -434,9 +434,13 @@
         <iframe src="https://dune.com/embeds/956036/1682330/03563d79-d652-4f8d-b291-497be54e1c63" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
         </iframe>
     </div>
-
     <div class="iframe-holder">
         <iframe src="https://dune.xyz/embeds/284182/536054/8efedf92-132d-43f9-974c-d6aaa2ad53b6" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
+        </iframe>
+    </div>
+
+    <div class="iframe-holder">
+        <iframe src="https://dune.com/embeds/1149021/1961517/e6381414-de7c-4e0d-b91a-d8ec2bfbead3" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
         </iframe>
     </div>
 

--- a/eagleproject/core/templates/dashboard.html
+++ b/eagleproject/core/templates/dashboard.html
@@ -440,7 +440,7 @@
     </div>
 
     <div class="iframe-holder">
-        <iframe src="https://dune.com/embeds/1149021/1961517/6ea00091-4df9-478b-aa9c-8f907856fc92" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
+        <iframe src="https://dune.com/embeds/1149021/1961517/6e89e0d2-0c00-4616-a7b1-9151c25dbcc9" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
         </iframe>
     </div>
 


### PR DESCRIPTION
this adds a chart to dashboard showing OUSD supply relative to total stablecoin supply on Ethereum, issue #216

https://dune.com/queries/1149021/1961517

