### PR TITLE
draft: add backing supply chart

### DIFF
--- a/eagleproject/core/templates/dashboard.html
+++ b/eagleproject/core/templates/dashboard.html
@@ -431,6 +431,11 @@
 
 <div class="columns d-flex flex-column">
     <div class="iframe-holder">
+        <iframe src="https://dune.com/embeds/1002271/1872453/3de4ff99-9dbb-417f-8c6c-f6373f41452c" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
+        </iframe>
+    </div>
+
+    <div class="iframe-holder">
         <iframe src="https://dune.com/embeds/956036/1682330/03563d79-d652-4f8d-b291-497be54e1c63" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
         </iframe>
     </div>


### PR DESCRIPTION
Adding chart with historical OUSD backing supply data, issue #185

Still a bit weird looking though

https://dune.com/queries/1002271