### PR TITLE
Add total number of token holders

### DIFF
--- a/eagleproject/core/templates/dashboard.html
+++ b/eagleproject/core/templates/dashboard.html
@@ -262,6 +262,10 @@
         font-size: 1.8rem;
     }
 
+    .floating-stat.larger {
+        width: 200px;
+    }
+
     .floating-stat .label {
         color: var(--dark-blue-grey);
         font-size: 0.875rem;
@@ -299,6 +303,14 @@
         }
         .logs .filters a {
             margin-left: 20px;
+        }
+        .hide-dune-title {
+            position: absolute;
+            top: 8px;
+            left: 286px;
+            min-width: 120px;
+            min-height: 30px;
+            background-color: #FAFBFC;
         }
     }
 </style>
@@ -414,6 +426,15 @@
     <div class="iframe-holder">
         <iframe src="https://dune.xyz/embeds/412267/786810/c0746688-f5a3-450e-b7ae-f6d7f86dec58" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">
         </iframe>
+        <div class="floating-stat d-flex flex-column align-items-center">
+            <div class="label">
+                Total amount of current token holders
+            </div>
+            <div class="no-wrap">
+                {{token_holder_amount|floatformat:0}}
+            </div>
+        </div>
+        <div class="hide-dune-title"></div>
     </div>
     <div class="iframe-holder">
         <iframe src="https://dune.xyz/embeds/415779/792793/c522b4f5-65e4-467b-ae8c-2aec9cc5e5af" width="100%" height="300" style="border:1px solid #999999; border-radius: 10px; margin-bottom: 20px;">

--- a/eagleproject/core/views.py
+++ b/eagleproject/core/views.py
@@ -113,6 +113,11 @@ def dashboard(request):
     if topic:
         logs_q = logs_q.filter(topic_0=topic)
     latest_logs = logs_q[:100]
+    weekly_reports = AnalyticsReport.objects.filter(
+        week__isnull=False
+    ).order_by("-year", "-week")
+    if (len(weekly_reports) > 0):
+        token_holder_amount = weekly_reports[0].accounts_holding_ousd
 
     filters = [
         {


### PR DESCRIPTION
This tackles https://github.com/OriginProtocol/ousd-analytics/issues/195
I am fetching token holders value from latest weekly report as it's a pretty intensive computation.

I verified locally the token holders number corresponds to the latest weekly report number (see screenshots). This number is not the correct one since I don't have all the reports computed locally.

![str](https://user-images.githubusercontent.com/5720927/202556970-884c9ee2-c4a3-4cc0-b1bf-281803a37449.png)

![str2](https://user-images.githubusercontent.com/5720927/202556916-df9a2e9a-69d4-4ea2-8e39-8c9cb46f4001.png)
