### PR TITLE
Update strategist validator with new contract

### DIFF
--- a/eagleproject/core/static/core/strategist/abi_vault_value_checker.js
+++ b/eagleproject/core/static/core/strategist/abi_vault_value_checker.js
@@ -9,6 +9,11 @@ const abiVaultValueChecker = {
           "internalType": "address",
           "name": "_vault",
           "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_ousd",
+          "type": "address"
         }
       ],
       "stateMutability": "nonpayable",
@@ -18,22 +23,61 @@ const abiVaultValueChecker = {
       "inputs": [
         {
           "internalType": "int256",
-          "name": "maxLoss",
+          "name": "lowValueDelta",
+          "type": "int256"
+        },
+        {
+          "internalType": "int256",
+          "name": "highValueDelta",
+          "type": "int256"
+        },
+        {
+          "internalType": "int256",
+          "name": "lowSupplyDelta",
+          "type": "int256"
+        },
+        {
+          "internalType": "int256",
+          "name": "highSupplyDelta",
           "type": "int256"
         }
       ],
-      "name": "checkLoss",
+      "name": "checkDelta",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "inputs": [],
-      "name": "snapshotValue",
+      "name": "ousd",
+      "outputs": [
+        {
+          "internalType": "contract OUSD",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "snapshots",
       "outputs": [
         {
           "internalType": "uint256",
-          "name": "",
+          "name": "vaultValue",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalSupply",
           "type": "uint256"
         }
       ],

--- a/eagleproject/core/static/core/strategist/strategist_validator.js
+++ b/eagleproject/core/static/core/strategist/strategist_validator.js
@@ -28,7 +28,7 @@ const strategistValidator = (function () {
 
   const MULTI_SEND_ADDRESS = "0x40a2accbd92bca938b02010e17a5b8929b49130d";
   const VAULT = "0xE75D77B1865Ae93c7eaa3040B038D7aA7BC02F70";
-  const CHECKER = "0x5B98B3255522E95f842967723Ee4Cc7dCEaa9150";
+  const CHECKER = "0xEEcD72c99749A1FC977704AB900a05e8300F4318";
 
   // App hooks up to events
   function app(opts) {


### PR DESCRIPTION
This blindly replaces the contract address and ABI for the new [VaultValueChecker](https://etherscan.io/address/0xEEcD72c99749A1FC977704AB900a05e8300F4318#code), which I'm unable to test in my local environment.