### PR TITLE
PoY-v0.75 accounting

### DIFF
--- a/eagleproject/core/blockchain/harvest/snapshots.py
+++ b/eagleproject/core/blockchain/harvest/snapshots.py
@@ -349,7 +349,7 @@ def ensure_asset(symbol, block_number, project=OriginTokens.OUSD):
     return ab
 
 
-def ensure_supply_snapshot(block_number, project=OriginTokens.OUSD):
+def ensure_supply_snapshot(block_number, project=OriginTokens.OUSD) -> SupplySnapshot:
     try:
         s = SupplySnapshot.objects.filter(block_number=block_number,project=project).first()
         if s is not None:

--- a/eagleproject/core/blockchain/harvest/transaction_history.py
+++ b/eagleproject/core/blockchain/harvest/transaction_history.py
@@ -1583,12 +1583,6 @@ def _daily_rows(steps, latest_block_number, project, start_at=0):
                 rebase_amount = 0
                 rebase_fee = 0
 
-                print(len(Log.objects.filter(
-                    topic_0=SIG_EVENT_YIELD_DISTRIBUTION,
-                    address=contract_address,
-                    transaction_hash=event.tx_hash
-                )))
-
                 yield_distribution_events = Log.objects.filter(
                     topic_0=SIG_EVENT_YIELD_DISTRIBUTION,
                     address=contract_address,

--- a/eagleproject/core/blockchain/harvest/transaction_history.py
+++ b/eagleproject/core/blockchain/harvest/transaction_history.py
@@ -1600,8 +1600,8 @@ def _daily_rows(steps, latest_block_number, project, start_at=0):
                     )              
                     
                     s.rebase_events.append({
-                        'amount': rebase_amount - rebase_fee,
-                        'fee': rebase_fee,
+                        'amount': (rebase_amount - rebase_fee) / 1e18,
+                        'fee': rebase_fee / 1e18,
                         'tx_hash': event.tx_hash,
                         'block_number': event.block_number,
                         'block_time': event.block_time,
@@ -1612,7 +1612,7 @@ def _daily_rows(steps, latest_block_number, project, start_at=0):
                 change = Decimal(0)
             else:
                 # other_change = 1 - (s.rebasing_credits_per_token / last_snapshot.rebasing_credits_per_token)
-                change = Decimal(sum(event['amount'] for event in s.rebase_events) / 1e18) / (s.computed_supply - s.non_rebasing_supply)
+                change = Decimal(sum(event['amount'] for event in s.rebase_events)) / (s.computed_supply - s.non_rebasing_supply)
 
                 
             s.apr = (
@@ -1630,6 +1630,8 @@ def _daily_rows(steps, latest_block_number, project, start_at=0):
             except (DivisionByZero, InvalidOperation):
                 s.unboosted = Decimal(0)
             s.gain = change * (s.computed_supply - s.non_rebasing_supply)
+            s.fees = Decimal(sum(event['fee'] for event in s.rebase_events))
+
         rows.append(s)
         last_snapshot = s
     rows.reverse()

--- a/eagleproject/core/views.py
+++ b/eagleproject/core/views.py
@@ -479,7 +479,17 @@ def api_daily_stats(request, project, days, start=0):
     rows = _daily_rows(int(days), latest_snapshot_block_number(project), project=project, start_at=int(start))
     response = JsonResponse(
         {
-            "daily": [{"date": x.effective_day, "apy": x.apy, "backing_supply" : x.computed_supply, "yield": x.gain} for x in rows],
+            "daily": [{
+                "date": x.effective_day,
+                "yield": x.gain, 
+                "backing_supply" : x.computed_supply, 
+                "rebasing_supply": x.rebasing_computed_supply(),
+                "non_rebasing_supply": x.non_rebasing_supply,
+                "apy": x.apy, 
+                "raw_apy": x.unboosted,
+                "apy_boost": x.non_rebasing_boost_multiplier(),
+                "rebase_events": x.rebase_events
+            } for x in rows],
         }
     )
     return _cache(120, response)

--- a/eagleproject/core/views.py
+++ b/eagleproject/core/views.py
@@ -482,6 +482,7 @@ def api_daily_stats(request, project, days, start=0):
             "daily": [{
                 "date": x.effective_day,
                 "yield": x.gain, 
+                "fees": x.fees,
                 "backing_supply" : x.computed_supply, 
                 "rebasing_supply": x.rebasing_computed_supply(),
                 "non_rebasing_supply": x.non_rebasing_supply,


### PR DESCRIPTION
The relevant accounting/data exposed for step 0.75 in Proof of Yield.

We want to be able fill out this section.
![image](https://github.com/OriginProtocol/ousd-analytics/assets/23041116/c4629017-4ce7-4f6c-bdc2-efe27340c3e5)

In this PR, I made a change to how the `change` (in percent) from one day to another was calculated. Previously, `change` was calculated by finding the difference in between `rebasing_credits_per_token` at the beginning and end of the time period, and dividing by the `rebasing_credits_per_token` at the beginning of the time period to receive a percentage. 

`change = 1 - (s.rebasing_credits_per_token / last_snapshot.rebasing_credits_per_token)`

However, later using this value to compute the total yield resulted in a discrepancy between the total yield, and the sum of the yields from the rebase events.

`s.gain = change * (s.computed_supply - s.non_rebasing_supply)`

This isn't great since I imagine the purpose of this section in PoY is to show that the rebase events do add up. So now I calculate `change` using the sum of the rebase events. 

`change = Decimal(sum(event['amount'] for event in s.rebase_events) / 1e18) / (s.computed_supply - s.non_rebasing_supply)`