### PR TITLE
Update precision for OETH metrics

### DIFF
--- a/eagleproject/core/templates/analytics_report_v2_base.html
+++ b/eagleproject/core/templates/analytics_report_v2_base.html
@@ -161,11 +161,11 @@
         <tr style="border-bottom: 1px solid #B5BECA;">
           <td><div class="field" style="text-align:left;padding-top: 14px;padding-bottom: 14px;">Circulating supply</div></td>
           <td style="font-weight:bold;">
-            <div class="cell value low-bottom-margin color-prev">{{prev_report|class_value:'circulating_oeth'|floatformat_rnd_down:2}}</div>
+            <div class="cell value low-bottom-margin color-prev">{{prev_report|class_value:'circulating_oeth'|floatformat_rnd_down:0}}</div>
             <div class="cell value usd color-na">(${{prev_report|oeth_circulating_supply_usd}})</div>
           </td>
           <td style="font-weight:bold;">
-            <div class="cell value low-bottom-margin">{{report|class_value:'circulating_oeth'|floatformat_rnd_down:2}}</div>
+            <div class="cell value low-bottom-margin">{{report|class_value:'circulating_oeth'|floatformat_rnd_down:0}}</div>
             <div class="cell value usd color-na">(${{report|oeth_circulating_supply_usd}})</div>
           </td>
           <td><span class="{{change|class_color_style:'circulating_oeth'}}"><div class="cell change top-aligned">{{change|dict_value:'circulating_oeth'|change_in_value}}</div></span></td>
@@ -173,11 +173,11 @@
         <tr style="border-bottom: 1px solid #B5BECA;">
           <td><div class="field" style="text-align:left;padding-top: 14px;padding-bottom: 14px;">Protocol-owned supply</div></td>
           <td style="font-weight:bold;">
-            <div class="cell value low-bottom-margin color-prev">{{prev_report|class_value:'protocol_owned_oeth'|floatformat_rnd_down:2}}</div>
+            <div class="cell value low-bottom-margin color-prev">{{prev_report|class_value:'protocol_owned_oeth'|floatformat_rnd_down:0}}</div>
             <div class="cell value usd color-na">(${{prev_report|oeth_protocol_supply_usd}})</div>
           </td>
           <td style="font-weight:bold;">
-            <div class="cell value low-bottom-margin">{{report|class_value:'protocol_owned_oeth'|floatformat_rnd_down:2}}</div>
+            <div class="cell value low-bottom-margin">{{report|class_value:'protocol_owned_oeth'|floatformat_rnd_down:0}}</div>
             <div class="cell value usd color-na">(${{report|oeth_protocol_supply_usd}})</div>
           </td>
           <td><span class="{{change|class_color_style:'protocol_owned_oeth'}}"><div class="cell change top-aligned">{{change|dict_value:'protocol_owned_oeth'|change_in_value}}</div></span></td>
@@ -203,9 +203,12 @@
             {%if statistic == "accounts_holding_more_than_dot1_oeth"%}
               <td style="font-weight:bold;"><div class="cell value color-prev">{{prev_report|class_value:statistic|default:"N/A"}}</div></td>
               <td style="font-weight:bold;"><div class="cell value">{{report|class_value:statistic}}</div></td>
+            {% elif statistic == "oeth_curve_supply"%}
+              <td style="font-weight:bold;"><div class="cell value color-prev">{{prev_report|class_value:statistic|default:"N/A"|floatformat_rnd_down:0}}</div></td>
+              <td style="font-weight:bold;"><div class="cell value">{{report|class_value:statistic|floatformat_rnd_down:0}}</div></td>
             {% else %}
-              <td style="font-weight:bold;"><div class="cell value color-prev">{{prev_report|class_value:statistic|default:"N/A"|floatformat_rnd_down:2}}</div></td>
-              <td style="font-weight:bold;"><div class="cell value">{{report|class_value:statistic|floatformat_rnd_down:2}}</div></td>
+              <td style="font-weight:bold;"><div class="cell value color-prev">{{prev_report|class_value:statistic|default:"N/A"|floatformat_rnd_down:3}}</div></td>
+              <td style="font-weight:bold;"><div class="cell value">{{report|class_value:statistic|floatformat_rnd_down:3}}</div></td>
             {% endif %}
             <td><span class="{{change|class_color_style:statistic}}"><div class="cell change">{{change|dict_value:statistic|change_in_value}}</div></span></td>
         </tr>

--- a/eagleproject/core/templatetags/blockchain.py
+++ b/eagleproject/core/templatetags/blockchain.py
@@ -496,12 +496,14 @@ def oeth_circulating_supply_usd(report):
     price = getattr(report, "average_oeth_price")
     supply = getattr(report, "circulating_oeth")
     return floatformat_rnd_down (
-        supply * price
+        supply * price,
+        0
     )
 @register.filter
 def oeth_protocol_supply_usd(report):
     price = getattr(report, "average_oeth_price")
     supply = getattr(report, "protocol_owned_oeth")
     return floatformat_rnd_down(
-        supply * price
+        supply * price,
+        0
     )


### PR DESCRIPTION
This is a blind PR but here are the intended outcomes:

- [x] Remove decimal places for circulating and protocol-owned supply (ETH and USD)
- [x] Remove decimals places for Curve pool supply
- [ ] Add a third decimal place for yield distributed, protocol fees, and trading volume