### PR TITLE
Add TVL history endpoint

### DIFF
--- a/eagleproject/eagleproject/urls.py
+++ b/eagleproject/eagleproject/urls.py
@@ -78,6 +78,7 @@ urlpatterns = [
     path("api/v2/<slug:project>/address/<slug:address>/yield", core_views.api_address_yield, name="api_address_yield"),
     path("api/v2/<slug:project>/address/", core_views.api_address),
     path("api/v2/<slug:project>/address/<slug:address>/history", core_views.api_address_history, name="api_address_history"),
+    path("api/v2/<slug:project>/tvl_history/<int:days>", core_views.tvl_history),
     path("api/v2/<slug:project>/strategies", core_views.strategies),
     path("api/v2/<slug:project>/collateral", core_views.collateral),
     path("api/v2/<slug:project>/apr/trailing_history/<int:days>", core_views.api_apr_trailing_history),


### PR DESCRIPTION
- Adds a TVL history endpoint
- Adds circulating supply, protocol-owned supply, block time and block numbers to `/strategies` endpoint

To get 7-day TVL history:
```
GET /api/v2/ousd/tvl_history/7
```

[Here's a sample 7-day response](https://github.com/OriginProtocol/ousd-analytics/files/12430847/7day-response.txt)
