### PR TITLE
remove 0 yield events

### DIFF
--- a/eagleproject/core/blockchain/harvest/transaction_history.py
+++ b/eagleproject/core/blockchain/harvest/transaction_history.py
@@ -1353,6 +1353,7 @@ def get_history_for_address(address, transaction_filter, project=OriginTokens.OU
         if isinstance(tx_history[i], rebase_log):
             if project != OriginTokens.WOUSD and project != OriginTokens.WOETH:
                 if transaction_filter == None or 'yield' in transaction_filter:
+                  if float(tx_history[i].amount) != 0:
                     tx_history_filtered.append({
                         'block_number': tx_history[i].block_number,
                         'time': tx_history[i].block_time,


### PR DESCRIPTION
some addresses have some OUSD/OETH dust left over, the address history endpoints return yield events for them even though the yield is too small to register a single decimal point - remove these from address history